### PR TITLE
feat(cronjobs): add cronjobs helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ helm registry login ghcr.io
 | [cloudflared](./charts/cloudflared) | 0.2.1 | 2024.11.0 | Deploy Cloudflare Tunnel for secure ingress |
 | [karpenter-nodepool](./charts/karpenter-nodepool) | 1.5.1 | 1.5.0 | Karpenter NodePool and EC2NodeClass resources |
 | [log-generator](./charts/log-generator) | 0.1.1 | latest | Configurable log generator for testing and benchmarking |
+| [cronjobs](./charts/cronjobs) | 0.1.0 | 1.16.0 | Generic CronJobs deployment chart |
 
 ## Quick Start
 
@@ -79,6 +80,16 @@ helm install log-generator duyhenryer/log-generator
 helm install log-generator duyhenryer/log-generator -f my-values.yaml
 ```
 
+### cronjobs - Generic CronJobs
+
+```bash
+# Install with default values
+helm install my-cronjobs duyhenryer/cronjobs
+
+# Install with custom values file
+helm install my-cronjobs duyhenryer/cronjobs -f values.yaml
+```
+
 ## Using OCI Registry
 
 ```bash
@@ -90,4 +101,7 @@ helm install karpenter-nodes oci://ghcr.io/duyhenryer/charts/karpenter-nodepool 
 
 # Pull and install log-generator
 helm install log-generator oci://ghcr.io/duyhenryer/charts/log-generator --version 0.1.3
+
+# Pull and install cronjobs
+helm install my-cronjobs oci://ghcr.io/duyhenryer/charts/cronjobs --version 0.1.0
 ```

--- a/charts/cronjobs/.helmignore
+++ b/charts/cronjobs/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cronjobs/CHANGELOG.md
+++ b/charts/cronjobs/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-02-07
+
+### Added
+- Initial release of the generic CronJobs Helm chart.
+- Support for multiple CronJob definitions in `values.yaml`.
+- Support for automatic `kubernetes.io/dockerconfigjson` Secret creation from `imagePullSecrets`.
+- Support for `ServiceAccount`, `SecurityContext`, `Resources`, `VolumeMounts`, `Affinity`, `Tolerations`.

--- a/charts/cronjobs/Chart.yaml
+++ b/charts/cronjobs/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: cronjobs
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/cronjobs/README.md
+++ b/charts/cronjobs/README.md
@@ -1,0 +1,126 @@
+# CronJobs Helm Chart
+
+## Configuration
+
+Via `values.yaml`
+
+### Overview
+
+```yaml
+jobs:
+  jobname-1:
+    # job definition
+  jobname-2:
+    # job definition
+  jobname-n:
+    # job definition
+```
+
+### Details
+
+```yaml
+jobs:
+  ### REQUIRED ###
+  <job_name>:
+    image:
+      repository: <image_repo>
+      tag: <image_tag>
+      imagePullPolicy: <pull_policy>
+    schedule: "<cron_schedule>"
+    failedJobsHistoryLimit: <failed_history_limit>
+    successfulJobsHistoryLimit: <successful_history_limit>
+    concurrencyPolicy: <concurrency_policy>
+    restartPolicy: <restart_policy>
+  ### OPTIONAL ###
+    imagePullSecrets:
+    - username: <user>
+      password: <password>
+      email: <email>
+      registry: <registry>
+    env:
+    - name: ENV_VAR
+      value: ENV_VALUE
+    envFrom:
+    - secretRef:
+      name: <secret_name>
+    - configMapRef:
+      name: <configmap_name>
+    command: ["<command>"]
+    args:
+    - "<arg_1>"
+    - "<arg_2>"
+    resources:
+      limits:
+        cpu: <cpu_count>
+        memory: <memory_count>
+      requests:
+        cpu: <cpu_count>
+        memory: <memory_count>
+    serviceAccount:
+      name: <account_name>
+      annotations:  # Optional
+        my-annotation-1: <value>
+        my-annotation-2: <value>
+    nodeSelector:
+      key: <value>
+    tolerations:
+    - effect: NoSchedule
+      operator: Exists
+    volumes:
+      - name: config-mount
+        configMap:
+          name: configmap-name
+          items:
+            - key: configuration.yml
+              path: configuration.yml
+    volumeMounts:
+      - name: config-mount
+        mountPath: /etc/config
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/e2e-az-name
+              operator: In
+              values:
+              - e2e-az1
+              - e2e-az2
+```
+
+## Examples
+
+```bash
+$ helm install test-cron-job .
+NAME:   cold-fly
+LAST DEPLOYED: Fri Feb  1 15:29:21 2019
+NAMESPACE: default
+STATUS: DEPLOYED
+
+RESOURCES:
+==> v1/CronJob
+NAME                    AGE
+cold-fly-hello-world    1s
+cold-fly-hello-ubuntu   1s
+cold-fly-hello-env-var  1s
+```
+
+List cronjobs:
+
+```bash
+$ kubectl get cronjob
+NAME                     SCHEDULE      SUSPEND   ACTIVE    LAST SCHEDULE   AGE
+cold-fly-hello-env-var   * * * * *     False     0         23s             1m
+cold-fly-hello-ubuntu    */5 * * * *   False     0         23s             1m
+cold-fly-hello-world     * * * * *     False     0         23s             1m
+```
+
+List jobs:
+
+```bash
+$ kubectl get jobs
+NAME                                DESIRED   SUCCESSFUL   AGE
+cold-fly-hello-env-var-1549056600   1         1            45s
+cold-fly-hello-ubuntu-1549056600    1         1            45s
+cold-fly-hello-world-1549056600     1         1            45s
+```

--- a/charts/cronjobs/templates/_helpers.tpl
+++ b/charts/cronjobs/templates/_helpers.tpl
@@ -1,0 +1,55 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cronjobs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cronjobs.labels" -}}
+helm.sh/chart: {{ include "cronjobs.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Expand the release name of the chart.
+*/}}
+{{- define "cronjobs.releaseName" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Create payload for any image pull secret.
+One kube secret will be created containing all the auths
+and will be shared by all the job pods requiring it.
+*/}}
+{{- define "cronjobs.imageSecrets" -}}
+    {{- $secrets := dict -}}
+    {{- range $jobname, $job := .Values.jobs -}}
+        {{- if hasKey $job "imagePullSecrets" -}}
+            {{- range $ips := $job.imagePullSecrets -}}
+                {{- $userInfo := dict "username" $ips.username "password" $ips.password "auth" (printf "%s:%s" $ips.username $ips.password | b64enc) -}}
+                {{- if hasKey $ips "email" -}}
+                    {{ $_ := set $userInfo  "email" $ips.email -}}
+                {{- end -}}
+                {{- $_ := set $secrets $ips.registry $userInfo -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+    {{- if gt (len $secrets) 0 -}}
+        {{- $auth := dict "auths" $secrets -}}
+        {{/* Emit secret content as base64 */}}
+        {{- print ($auth | toJson | b64enc) -}}
+    {{- else -}}
+        {{/* There are no secrets*/}}
+        {{- print "" -}}
+    {{- end -}}
+{{- end -}}

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -1,0 +1,88 @@
+{{- range $jobname, $job := .Values.jobs }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "cronjobs.releaseName" $ }}-{{ $jobname }}
+  labels:
+    {{- include "cronjobs.labels" $ | nindent 4 }}
+spec:
+  concurrencyPolicy: {{ $job.concurrencyPolicy }}
+  failedJobsHistoryLimit: {{ $job.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: {{ include "cronjobs.releaseName" $ }}
+            cron: {{ $jobname }}
+        spec:
+        {{- if hasKey $job "imagePullSecrets" }}
+          imagePullSecrets:
+          - name: {{ $.Release.Name }}-docker
+        {{- end }}
+        {{- if and (hasKey $job "serviceAccount") (hasKey $job.serviceAccount "name") }}
+          serviceAccountName: {{ $job.serviceAccount.name }}
+        {{- else }}
+          serviceAccountName: {{ $.Release.Name}}-{{ $jobname }}
+        {{- end }}
+        {{- if hasKey $job "securityContext" }}
+          {{- if $job.securityContext.runAsUser }}
+          securityContext:
+            runAsUser: {{ $job.securityContext.runAsUser }}
+            {{- if $job.securityContext.runAsGroup }}
+            runAsGroup: {{ $job.securityContext.runAsGroup }}
+            {{- end }}
+            {{- if $job.securityContext.fsGroup }}
+            fsGroup: {{ $job.securityContext.fsGroup }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+          containers:
+          - image: {{ $job.image.repository }}:{{ $job.image.tag }}
+            imagePullPolicy: {{ $job.image.imagePullPolicy }}
+            name: {{ $jobname }}
+            {{- with $job.env }}
+            env:
+{{ toYaml . | indent 12 }}
+            {{- end }}
+            {{- with $job.envFrom }}
+            envFrom:
+{{ toYaml . | indent 12 }}
+            {{- end }}
+            {{- with $job.command }}
+            command:
+{{ toYaml . | indent 12 }}
+            {{- end }}
+            {{- with $job.args }}
+            args:
+{{ toYaml . | indent 12 }}
+              {{- end }}
+            {{- with $job.resources }}
+            resources:
+{{ toYaml . | indent 14 }}
+            {{- end }}
+            {{- with $job.volumeMounts }}
+            volumeMounts:
+{{ toYaml . | indent 12 }}
+            {{- end }}
+          {{- with $job.nodeSelector }}
+          nodeSelector:
+{{ toYaml . | indent 12 }}
+          {{- end }}
+          {{- with $job.affinity }}
+          affinity:
+{{ toYaml . | indent 12 }}
+          {{- end }}
+          {{- with $job.tolerations }}
+          tolerations:
+{{ toYaml . | indent 12 }}
+          {{- end }}
+          restartPolicy: {{ $job.restartPolicy }}
+          {{- with $job.volumes }}
+          volumes:
+{{ toYaml . | indent 12 }}
+          {{- end }}
+  schedule: {{ $job.schedule | quote }}
+  successfulJobsHistoryLimit: {{ $job.successfulJobsHistoryLimit }}
+{{- end }}

--- a/charts/cronjobs/templates/secret.yaml
+++ b/charts/cronjobs/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- $secret := (include "cronjobs.imageSecrets" .) -}}
+{{- if ne $secret "" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-docker
+  labels:
+    {{- include "cronjobs.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ $secret }}
+{{- end -}}

--- a/charts/cronjobs/templates/serviceaccount.yaml
+++ b/charts/cronjobs/templates/serviceaccount.yaml
@@ -1,0 +1,20 @@
+{{- range $jobname, $job := .Values.jobs }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- if and (hasKey $job "serviceAccount") (hasKey $job.serviceAccount "name") }}
+  name: {{ $job.serviceAccount.name }}
+  {{- else }}
+  name: {{ $.Release.Name}}-{{ $jobname }}
+  {{- end }}
+  labels:
+    {{- include "cronjobs.labels" $ | nindent 4 }}
+    cron: {{ $jobname }}
+  {{- if and (hasKey $job "serviceAccount") (hasKey $job.serviceAccount "annotations") }}
+  {{- with $job.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/cronjobs/values.yaml
+++ b/charts/cronjobs/values.yaml
@@ -1,0 +1,101 @@
+# Default values for cronjobs.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+jobs:
+  # first cron
+  hello-world:
+    image:
+      repository: hello-world
+      tag: latest
+      imagePullPolicy: IfNotPresent
+    schedule: "* * * * *"
+    failedJobsHistoryLimit: 1
+    successfulJobsHistoryLimit: 3
+    concurrencyPolicy: Allow
+    restartPolicy: OnFailure
+    imagePullSecrets:
+    - username: fred
+      password: password
+      registry: docker.io
+  # second cron
+  hello-ubuntu:
+    image:
+      repository: ubuntu
+      tag: latest
+      imagePullPolicy: Always
+    schedule: "*/5 * * * *"
+    command: ["/bin/bash"]
+    args:
+      - "-c"
+      - "echo $(date) - hello from ubuntu"
+    resources:
+      limits:
+        cpu: 50m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 256Mi
+    failedJobsHistoryLimit: 1
+    successfulJobsHistoryLimit: 3
+    concurrencyPolicy: Forbid
+    restartPolicy: OnFailure
+    imagePullSecrets:
+    - username: joe
+      password: password2
+      email: joe@example.com
+      registry: quay.io
+  # third cron
+  hello-env-var:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 2000
+    image:
+      repository: busybox
+      tag: latest
+      imagePullPolicy: Always
+    # optional env vars
+    env:
+    - name: ECHO_VAR
+      value: "busybox"
+    envFrom:
+        - secretRef:
+            name: secret-data
+        - configMapRef:
+            name: config-data
+    schedule: "* * * * *"
+    command: ["/bin/sh"]
+    args:
+      - "-c"
+      - "echo $(date) - hello from $ECHO_VAR"
+      - "echo $(date) - loaded secret $secret_data"
+      - "echo $(date) - loaded config $config_data"
+    serviceAccount:
+      name: "busybox-serviceaccount"
+    resources:
+      limits:
+        cpu: 50m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 256Mi
+    failedJobsHistoryLimit: 1
+    successfulJobsHistoryLimit: 3
+    concurrencyPolicy: Forbid
+    restartPolicy: Never
+    nodeSelector:
+      type: infra
+    tolerations:
+    - effect: NoSchedule
+      operator: Exists
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/e2e-az-name
+              operator: In
+              values:
+              - e2e-az1
+              - e2e-az2


### PR DESCRIPTION
## Summary by Sourcery

Add a new generic Helm chart for managing Kubernetes CronJobs via configurable job definitions.

New Features:
- Introduce a cronjobs Helm chart that supports defining multiple CronJobs through a single values file.
- Add support for configuring per-job image settings, schedules, resource limits, environment variables, node scheduling, and security context.
- Automatically generate ServiceAccounts and optional Docker registry Secrets for jobs based on imagePullSecrets configuration.

Enhancements:
- Provide helper templates for common chart labels, release naming, and aggregation of image pull secrets into a single dockerconfigjson Secret.

Documentation:
- Document configuration options and usage examples for the new cronjobs Helm chart in a dedicated README.

Chores:
- Add initial chart metadata, changelog, and Helm ignore file for the cronjobs chart.